### PR TITLE
Restrict guest actions

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,27 +38,42 @@ def main():
         # Dashboard
 
         session = get_session(os.environ["CQ_DATABASE_URL"])
-        cq_data = session.query(CQ).filter(
-            (CQ.author_id == st.session_state.user_id) |
-            (CQ.access_authorization == "Can be read by other registered users") |
-            (CQ.access_authorization == "Can be read by unregistered guests")
-        ).all()
+        if st.session_state.is_guest:
+            cq_data = session.query(CQ).filter(
+                CQ.access_authorization == "Can be read by unregistered guests"
+            ).all()
+        else:
+            cq_data = session.query(CQ).filter(
+                (CQ.author_id == st.session_state.user_id) |
+                (CQ.access_authorization == "Can be read by other registered users") |
+                (CQ.access_authorization == "Can be read by unregistered guests")
+            ).all()
         session.close()
 
         session = get_session(os.environ["TRANSCRIPTION_DATABASE_URL"])
-        transcription_data = session.query(Transcription).filter(
-            (Transcription.author_id == st.session_state.user_id) |
-            (Transcription.access_authorization == "Can be read by other registered users") |
-            (Transcription.access_authorization == "Can be read by unregistered guests")
-        ).all()
+        if st.session_state.is_guest:
+            transcription_data = session.query(Transcription).filter(
+                Transcription.access_authorization == "Can be read by unregistered guests"
+            ).all()
+        else:
+            transcription_data = session.query(Transcription).filter(
+                (Transcription.author_id == st.session_state.user_id) |
+                (Transcription.access_authorization == "Can be read by other registered users") |
+                (Transcription.access_authorization == "Can be read by unregistered guests")
+            ).all()
         session.close()
 
         session = get_session(os.environ["LCQ_DATABASE_URL"])
-        lcq_data = session.query(LegacyCQ).filter(
-            (LegacyCQ.author_id == st.session_state.user_id) |
-            (LegacyCQ.access_authorization == "Can be read by other registered users") |
-            (LegacyCQ.access_authorization == "Can be read by unregistered guests")
-        ).all()
+        if st.session_state.is_guest:
+            lcq_data = session.query(LegacyCQ).filter(
+                LegacyCQ.access_authorization == "Can be read by unregistered guests"
+            ).all()
+        else:
+            lcq_data = session.query(LegacyCQ).filter(
+                (LegacyCQ.author_id == st.session_state.user_id) |
+                (LegacyCQ.access_authorization == "Can be read by other registered users") |
+                (LegacyCQ.access_authorization == "Can be read by unregistered guests")
+            ).all()
         session.close()
 
         st.subheader("Conversational Questionnaires")
@@ -102,119 +117,122 @@ def main():
         st.dataframe(pd.DataFrame(lcq_data_list))
 
         # Upload Section
-        st.header("Upload CQ, Transcription or Legacy CQ")
-        upload_type = st.selectbox("Select Upload Type", ["CQ", "Transcription", "Legacy CQ"])
-        upload_version = ""
-        uploaded_file = None
-        if upload_type == "Legacy CQ":
-            uploaded_file = st.file_uploader("Legacy CQ File")
-        elif upload_type == "CQ":
-            uploaded_file = st.file_uploader("CQ JSON File", type=["json"])
-            upload_version = st.text_input("Version")
+        if st.session_state.is_guest:
+            st.header("Register to upload document")
         else:
-            uploaded_file = st.file_uploader("Transcription JSON File", type=["json"])
-            upload_version = st.text_input("Version")
-        upload_access_authorization = st.selectbox(
-            "Access Authorization",
-            [
-                "No sharing",
-                "Can be read by other registered users",
-                "Can be read by unregistered guests",
-            ],
-        )
+            st.header("Upload CQ, Transcription or Legacy CQ")
+            upload_type = st.selectbox("Select Upload Type", ["CQ", "Transcription", "Legacy CQ"])
+            upload_version = ""
+            uploaded_file = None
+            if upload_type == "Legacy CQ":
+                uploaded_file = st.file_uploader("Legacy CQ File")
+            elif upload_type == "CQ":
+                uploaded_file = st.file_uploader("CQ JSON File", type=["json"])
+                upload_version = st.text_input("Version")
+            else:
+                uploaded_file = st.file_uploader("Transcription JSON File", type=["json"])
+                upload_version = st.text_input("Version")
+            upload_access_authorization = st.selectbox(
+                "Access Authorization",
+                [
+                    "No sharing",
+                    "Can be read by other registered users",
+                    "Can be read by unregistered guests",
+                ],
+            )
 
-        if upload_type == "Transcription" and uploaded_file:
-            try:
-                json_text = uploaded_file.getvalue().decode("utf-8")
-                json_data = json.loads(json_text)
-            except Exception:
-                st.error("Invalid JSON file.")
-                json_data = None
-            if json_data:
-                session = get_session(os.environ["CQ_DATABASE_URL"])
-                cq_uid = json_data.get("cq_uid")
-                if cq_uid is not None:
-                    cq_uid = str(cq_uid)
-                cq_match = session.query(CQ).filter(CQ.uid == cq_uid).first()
-                session.close()
-                if cq_match:
-                    cq_title = cq_match.json_data.get("title", "Unknown title")
-                    confirm_cq = st.radio(f"CQ used: {cq_title}", ["yes", "no"], index=0)
-                else:
-                    st.warning("There is no CQ corresponding to this transcription")
-                    confirm_cq = None
-
-                pivot_language = st.text_input("Pivot language", value=json_data.get("pivot language", ""))
-                target_language = st.text_input("Target language", value=json_data.get("target language", ""))
-                interviewer = st.text_input("Interviewer name", value=json_data.get("interviewer", ""))
-                consultant = st.text_input("Consultant name", value=json_data.get("consultant", ""))
-                consultant_auth = st.checkbox("I have authorization from the consultant to upload this transcription")
-
-                if st.button("Upload"):
-                    if cq_match is None:
-                        st.error("There is no CQ corresponding to this transcription")
-                    elif confirm_cq == "no":
-                        st.error("There is a CQ-Transcription mismatch")
-                    elif not consultant_auth:
-                        st.error("Please confirm you have the consultant's authorization")
-                    elif not upload_version:
-                        st.error("Please enter a version.")
+            if upload_type == "Transcription" and uploaded_file:
+                try:
+                    json_text = uploaded_file.getvalue().decode("utf-8")
+                    json_data = json.loads(json_text)
+                except Exception:
+                    st.error("Invalid JSON file.")
+                    json_data = None
+                if json_data:
+                    session = get_session(os.environ["CQ_DATABASE_URL"])
+                    cq_uid = json_data.get("cq_uid")
+                    if cq_uid is not None:
+                        cq_uid = str(cq_uid)
+                    cq_match = session.query(CQ).filter(CQ.uid == cq_uid).first()
+                    session.close()
+                    if cq_match:
+                        cq_title = cq_match.json_data.get("title", "Unknown title")
+                        confirm_cq = st.radio(f"CQ used: {cq_title}", ["yes", "no"], index=0)
                     else:
-                        json_data["pivot language"] = pivot_language
-                        json_data["target language"] = target_language
-                        json_data["interviewer"] = interviewer
-                        json_data["consultant"] = consultant
-                        session = get_session(os.environ["TRANSCRIPTION_DATABASE_URL"])
-                        new_transcription = Transcription(
-                            json_data=json_data,
-                            author_id=st.session_state.user_id,
-                            version=upload_version,
-                            access_authorization=upload_access_authorization,
-                        )
-                        session.add(new_transcription)
-                        session.commit()
-                        session.close()
-                        st.success("Transcription data uploaded successfully!")
-        else:
-            if st.button("Upload"):
-                if uploaded_file and upload_access_authorization:
-                    if upload_type == "Legacy CQ":
-                        session = get_session(os.environ["LCQ_DATABASE_URL"])
-                        new_lcq = LegacyCQ(
-                            filename=uploaded_file.name,
-                            file_data=uploaded_file.read(),
-                            author_id=st.session_state.user_id,
-                            access_authorization=upload_access_authorization,
-                        )
-                        session.add(new_lcq)
-                        session.commit()
-                        session.close()
-                        st.success("Legacy CQ uploaded successfully!")
-                    else:
-                        if upload_version:
-                            try:
-                                json_text = uploaded_file.read().decode("utf-8")
-                                json_data = json.loads(json_text)
-                            except Exception:
-                                st.error("Invalid JSON file.")
-                            else:
-                                if upload_type == "CQ":
-                                    session = get_session(os.environ["CQ_DATABASE_URL"])
-                                    new_cq = CQ(
-                                        uid=json_data.get("uid"),
-                                        json_data=json_data,
-                                        author_id=st.session_state.user_id,
-                                        version=upload_version,
-                                        access_authorization=upload_access_authorization,
-                                    )
-                                    session.add(new_cq)
-                                    session.commit()
-                                    session.close()
-                                    st.success("CQ data uploaded successfully!")
-                        else:
+                        st.warning("There is no CQ corresponding to this transcription")
+                        confirm_cq = None
+
+                    pivot_language = st.text_input("Pivot language", value=json_data.get("pivot language", ""))
+                    target_language = st.text_input("Target language", value=json_data.get("target language", ""))
+                    interviewer = st.text_input("Interviewer name", value=json_data.get("interviewer", ""))
+                    consultant = st.text_input("Consultant name", value=json_data.get("consultant", ""))
+                    consultant_auth = st.checkbox("I have authorization from the consultant to upload this transcription")
+
+                    if st.button("Upload"):
+                        if cq_match is None:
+                            st.error("There is no CQ corresponding to this transcription")
+                        elif confirm_cq == "no":
+                            st.error("There is a CQ-Transcription mismatch")
+                        elif not consultant_auth:
+                            st.error("Please confirm you have the consultant's authorization")
+                        elif not upload_version:
                             st.error("Please enter a version.")
-                else:
-                    st.error("Please select a file and authorization.")
+                        else:
+                            json_data["pivot language"] = pivot_language
+                            json_data["target language"] = target_language
+                            json_data["interviewer"] = interviewer
+                            json_data["consultant"] = consultant
+                            session = get_session(os.environ["TRANSCRIPTION_DATABASE_URL"])
+                            new_transcription = Transcription(
+                                json_data=json_data,
+                                author_id=st.session_state.user_id,
+                                version=upload_version,
+                                access_authorization=upload_access_authorization,
+                            )
+                            session.add(new_transcription)
+                            session.commit()
+                            session.close()
+                            st.success("Transcription data uploaded successfully!")
+            else:
+                if st.button("Upload"):
+                    if uploaded_file and upload_access_authorization:
+                        if upload_type == "Legacy CQ":
+                            session = get_session(os.environ["LCQ_DATABASE_URL"])
+                            new_lcq = LegacyCQ(
+                                filename=uploaded_file.name,
+                                file_data=uploaded_file.read(),
+                                author_id=st.session_state.user_id,
+                                access_authorization=upload_access_authorization,
+                            )
+                            session.add(new_lcq)
+                            session.commit()
+                            session.close()
+                            st.success("Legacy CQ uploaded successfully!")
+                        else:
+                            if upload_version:
+                                try:
+                                    json_text = uploaded_file.read().decode("utf-8")
+                                    json_data = json.loads(json_text)
+                                except Exception:
+                                    st.error("Invalid JSON file.")
+                                else:
+                                    if upload_type == "CQ":
+                                        session = get_session(os.environ["CQ_DATABASE_URL"])
+                                        new_cq = CQ(
+                                            uid=json_data.get("uid"),
+                                            json_data=json_data,
+                                            author_id=st.session_state.user_id,
+                                            version=upload_version,
+                                            access_authorization=upload_access_authorization,
+                                        )
+                                        session.add(new_cq)
+                                        session.commit()
+                                        session.close()
+                                        st.success("CQ data uploaded successfully!")
+                            else:
+                                st.error("Please enter a version.")
+                    else:
+                        st.error("Please select a file and authorization.")
 
         # Change Password
         if not st.session_state.is_guest:


### PR DESCRIPTION
## Summary
- guests can only view content shared with unregistered users
- guests now see a prompt to register instead of upload section

## Testing
- `python3 -m py_compile main.py user_service.py models.py auth.py`
- `pytest -q`