### PR TITLE
Implement automatic document versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,6 @@ The login page now includes a "Login as Guest" button. Guests don't need to regi
 
 ### Legacy CQ Uploads
 Logged in users can also upload and download legacy CQ documents (Word, Excel, PDF...). These files are stored in a dedicated database.
+
+### Automatic Document Versioning
+When a user uploads a document, DIG4EL now manages version numbers automatically. If the filename has never been uploaded before, the file is stored with version `1`. When the filename already exists, users can choose to update the existing entry. Updating replaces the previous content and increments the version number. Selecting "No" cancels the upload.


### PR DESCRIPTION
## Summary
- add filename and version columns to CQ and Transcription
- add version column to LegacyCQ and make sure tables have them
- manage file versioning automatically when uploading documents
- document new automatic versioning feature

## Testing
- `python -m py_compile main.py models.py user_service.py auth.py`
- `pytest -q`