### PR TITLE
Allow free text interviewer/consultant for legacy CQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ When uploading a CQ, the user can choose a sharing authorization among: "No shar
 The login page now includes a "Login as Guest" button. Guests don't need to register (no username, email, or password needed). They can use the software but are restricted in their actions (they can't upload anything, or read content reserved to registered users).
 
 ### Legacy CQ Uploads
-Logged in users can also upload and download legacy CQ documents (Word, Excel, PDF...). These files are stored in a dedicated database.
+Logged in users can also upload and download legacy CQ documents (Word, Excel, PDF...). These files are stored in a dedicated database. When uploading a Legacy CQ the user simply provides the interviewer and consultant names. They don't need to correspond to registered usernames, but both fields must be filled and the uploader must certify authorisation via the checkbox.
 
 ### Automatic Document Versioning
 When a user uploads a document, DIG4EL now manages version numbers automatically. If the filename has never been uploaded before, the file is stored with version `1`. When the filename already exists, users can choose to update the existing entry. Updating replaces the previous content and increments the version number. Selecting "No" cancels the upload.

--- a/main.py
+++ b/main.py
@@ -218,21 +218,11 @@ def main():
                     f"{lcq.author.first_name or ''} {lcq.author.last_name or ''}"
                 ).strip() or lcq.author.username
 
-                interviewer_user = session_lcq.query(User).get(lcq.interviewer)
-                interviewer_name = (
-                    f"{interviewer_user.first_name or ''} {interviewer_user.last_name or ''}"
-                ).strip() if interviewer_user else "unknown"
-
-                consultant_user = session_lcq.query(User).get(lcq.consultant)
-                consultant_name = (
-                    f"{consultant_user.first_name or ''} {consultant_user.last_name or ''}"
-                ).strip() if consultant_user else "unknown"
-
                 lcq_data_list.append(
                     {
                         "filename": lcq.filename,
-                        "Interviewer": interviewer_name or (interviewer_user.username if interviewer_user else ""),
-                        "Consultant": consultant_name or (consultant_user.username if consultant_user else ""),
+                        "Interviewer": lcq.interviewer,
+                        "Consultant": lcq.consultant,
                         "author": author_name,
                         "last update": lcq.last_update_date,
                         "access": lcq.access_authorization,
@@ -408,23 +398,21 @@ def main():
                                     st.info("Upload cancelled")
                                     session.close()
                                 else:
-                                    interviewer_user = session.query(User).filter(User.username == interviewer_name).first()
-                                    consultant_user = session.query(User).filter(User.username == consultant_name).first()
-                                    if not interviewer_user or not consultant_user:
-                                        st.error("Interviewer or consultant not found")
+                                    if not interviewer_name or not consultant_name:
+                                        st.error("Please provide interviewer and consultant names")
                                         session.close()
                                     else:
                                         if existing:
-                                            existing.interviewer = interviewer_user.id
-                                            existing.consultant = consultant_user.id
+                                            existing.interviewer = interviewer_name
+                                            existing.consultant = consultant_name
                                             existing.author_id = st.session_state.user_id
                                             existing.access_authorization = upload_access_authorization
                                             existing.version = str(int(existing.version) + 1)
                                         else:
                                             new_lcq = LegacyCQ(
                                                 filename=uploaded_file.name,
-                                                interviewer=interviewer_user.id,
-                                                consultant=consultant_user.id,
+                                                interviewer=interviewer_name,
+                                                consultant=consultant_name,
                                                 author_id=st.session_state.user_id,
                                                 version="1",
                                                 access_authorization=upload_access_authorization,


### PR DESCRIPTION
## Summary
- allow interviewer and consultant names on legacy CQ uploads
- migrate legacy_cq DB table to use VARCHAR columns
- store and display the provided names
- document the change

## Testing
- `python -m py_compile main.py models.py user_service.py auth.py`